### PR TITLE
Fix: allow filenames with spaces

### DIFF
--- a/src/lib/git.spec.ts
+++ b/src/lib/git.spec.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 Marco Stahl */
+/* Copyright (c) 2018-2019 Marco Stahl */
 
 // tslint:disable:no-expression-statement no-object-mutation
 
@@ -15,6 +15,10 @@ test('getFileInfoFromGit', t => {
 });
 
 test('invertedGrepOptions', t => {
-  t.is(testExports.invertedGrepOptions('pattern'), '--invert-grep --grep=pattern');
-  t.is(testExports.invertedGrepOptions(), '');
+  t.deepEqual(testExports.invertedGrepOptions('pattern'), ['--invert-grep', '--grep=pattern']);
+  t.deepEqual(testExports.invertedGrepOptions(), []);
+});
+
+test('execToLines error', t => {
+  t.throws(() => testExports.execToLines([]), /No command to exec/);
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
copyright-header throws an error if it encounters a filename with spaces:
```console
$ node build/main/cli.js --copyrightHolder Someone --include "test-data/file with spaces.ts"
fatal: --follow requires exactly one pathspec
child_process.js:651
    throw err;
    ^

Error: Command failed: git log --format=%aD --follow  -- test-data/file with spaces.ts
fatal: --follow requires exactly one pathspec

    at checkExecSyncError (child_process.js:611:11)
    at Object.execSync (child_process.js:648:13)
    at execToLines (/home/mark/oss/copyright-header/build/main/lib/git.js:15:10)
    at Object.getFileInfoFromGit (/home/mark/oss/copyright-header/build/main/lib/git.js:28:22)
    at files.map.f (/home/mark/oss/copyright-header/build/main/lib/copyright-header.js:35:66)
    at Array.map (<anonymous>)
    at Object.ensureUpdatedCopyrightHeader (/home/mark/oss/copyright-header/build/main/lib/copyright-header.js:35:29)
    at Object.runCli (/home/mark/oss/copyright-header/build/main/lib/cli.js:30:39)
    at Object.<anonymous> (/home/mark/oss/copyright-header/build/main/cli.js:6:24)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
```

* **What is the new behavior (if this is a feature change)?**



* **Other information**:
The issue appears to be due to allowing the shell (via execSync) to parse the git command line without escaping the filename.

    Rather than escaping filenames, I believe the right approach is to use execFileSync instead.
