### PR TITLE
Fix: Exclude list is ignored if --exclude used without --include

### DIFF
--- a/src/lib/copyright-header.ts
+++ b/src/lib/copyright-header.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 Marco Stahl */
+/* Copyright (c) 2018-2019 Marco Stahl */
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -85,7 +85,7 @@ function collectFiles(fileFilter: FileFilter): ReadonlyArray<string> {
 
   const excludeRegexps = fileFilter.exclude.map(pattern => new RegExp(pattern));
   const excludeFilter = (filename: string) =>
-    includeRegexps.length === 0 || !excludeRegexps.some(regexp => regexp.test(filename));
+    excludeRegexps.length === 0 || !excludeRegexps.some(regexp => regexp.test(filename));
 
   return gitFiles
     .filter(includeFilter)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
If `--exclude` is used without also using `--include`, the specified excludes are ignored.

* **What is the new behavior (if this is a feature change)?**


* **Other information**:
The issue appears to be that the `excludeFilter` function always returns true (i.e. include all files) if `includeRegexps.length` is zero (i.e. if no includes were specified).
