### PR TITLE
fix: Insert copyright header after hashbang line

### DIFF
--- a/src/lib/copyright-header.spec.ts
+++ b/src/lib/copyright-header.spec.ts
@@ -3,9 +3,11 @@
 // tslint:disable:no-expression-statement no-object-mutation
 
 import test, { ExecutionContext } from 'ava';
-import { testExports } from './copyright-header';
+import { testExports, ValidatedOptions } from './copyright-header';
+import { TEMPLATES } from './templates';
+import { FileInfo } from './types';
 
-const { collectFiles, useTodayAsYearDefault } = testExports;
+const { collectFiles, updateCopyrightHeader, useTodayAsYearDefault } = testExports;
 
 const collectFilesTest = (
   t: ExecutionContext<unknown>,
@@ -51,4 +53,38 @@ test('useTodayAsYearDefault', t => {
     createdYear: thisYear,
     updatedYear: thisYear
   });
+});
+
+const testOpts: ValidatedOptions = {
+  copyrightHolder: 'Test User, Inc.',
+  fix: true,
+  include: ['test/file.ts'],
+  exclude: [],
+  template: TEMPLATES.minimal
+};
+
+const testFileInfo: FileInfo = {
+  filename: 'test/file.ts',
+  createdYear: 2002,
+  updatedYear: 2017
+};
+
+test('hashbang', t => {
+  const origFile = ['#!/bin/sh -some -options', 'File content', 'is here', ''].join('\n');
+  const expected = [
+    '#!/bin/sh -some -options',
+    '',
+    '/* Copyright (c) 2002-2017 Test User, Inc. */',
+    '',
+    'File content',
+    'is here',
+    ''
+  ].join('\n');
+
+  let updated = updateCopyrightHeader(testOpts, testFileInfo, origFile);
+  t.is(updated, expected);
+
+  // Run a second time to ensure idempotence
+  updated = updateCopyrightHeader(testOpts, testFileInfo, updated);
+  t.is(updated, expected);
 });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Currently, if copyright-header is run on a (unix) executable script that starts with `#!` (also known as a shebang or hashbang line), it inserts the copyright header before the `#!` line, which makes the script inoperable.

* **What is the new behavior (if this is a feature change)?**

The fix is to detect a hashbang line in a source file and insert the copyright header **after** that line, but before the rest of the file.

* **Other information**:

I also relaxed the requirement that there be absolutely no whitespace prior to the copyright header and now leave that leading whitespace in place. That applies both to the case where there's a hashbang (and the whitespace is between the hashbang and the copyright header) and also to the normal case where there might be whitespace before the copyright header.

It's combined with this change mostly due to the fact that I happened to have some whitespace in my own test files that was causing issues while debugging. But I felt it was a reasonable change to leave in. If you disagree, let me know.
